### PR TITLE
API docs: public docs should not link to private fields

### DIFF
--- a/lib/src/components/material_tooltip/src/tooltip.dart
+++ b/lib/src/components/material_tooltip/src/tooltip.dart
@@ -108,7 +108,7 @@ class MaterialTooltipDirective extends TooltipTarget
 
   bool _twoLine = false;
 
-  /// Shows the tooltip if [_show] is true, initializing and loading it into
+  /// Shows the tooltip if `_show` is true, initializing and loading it into
   /// the view it if is not already.
   void openTooltip() {
     if (!_show || !_closing) return;

--- a/lib/src/components/scorecard/scoreboard.dart
+++ b/lib/src/components/scorecard/scoreboard.dart
@@ -140,7 +140,7 @@ class ScoreboardComponent implements OnInit, OnDestroy {
   /// Whether allow scrolling the scoreboard via scroll buttons.
   ///
   /// Scrollable property can be set dynamically during app runtime -- will add
-  /// or remove window resize listener depending on state of [_scrollable].
+  /// or remove window resize listener depending on state of `_scrollable`.
   @Input()
   set scrollable(scrollable) {
     var value = getBool(scrollable);


### PR DESCRIPTION
This is a minimal fix to ensure that the API docs don't contain unreachable links (404s). The doc comments in question will eventually need to be further reworked so that public doc comments don't refer to private fields at all.