### PR TITLE
API docs(MD popup): fix broken link and code sample formatting

### DIFF
--- a/lib/src/components/material_popup/material_popup.dart
+++ b/lib/src/components/material_popup/material_popup.dart
@@ -27,8 +27,7 @@ export '../../laminate/popup/popup.dart' show PopupSourceDirective;
 /// Caveats:
 /// - Popups closing and opening are automatically delayed to add animations
 /// - An additional event, `animationComplete`, is available.
-/// - Take advantage of enforceSpaceConstraints defined in
-/// [PopupInterface](https://github.com/dart-lang/angular_components/tree/master/lib/src/laminate/components/popup/src/base.dart).
+/// - Take advantage of enforceSpaceConstraints defined in [PopupInterface].
 ///
 /// This is useful if content size is such that adds scroll to the page.
 /// - Even though this component supports [ChangeDetectionStrategy.OnPush]
@@ -42,9 +41,11 @@ export '../../laminate/popup/popup.dart' show PopupSourceDirective;
 ///  [trackLayoutChanges] which is also defined in [PopupInterface].
 ///
 /// __Events__:
+/// 
 /// - `animationComplete`: Triggers after an open or close animation finishes.
 ///
 /// __Example use__:
+/// 
 ///     <button (click)="showPopup = !showPopup"
 ///             popupSource
 ///             #source="popupSource">
@@ -55,6 +56,7 @@ export '../../laminate/popup/popup.dart' show PopupSourceDirective;
 ///     </material-popup>
 ///
 /// Material popup also supports deferred/lazy-loaded content:
+/// 
 ///     <material-popup [visible]="showPopup" [source]="source">
 ///       <expensive-component *deferredContent></expensive-component>
 ///     </material-popup>


### PR DESCRIPTION
- An external link (to GitHub) for `PopupInterface` was wrong. It has been removed.
- Sample code was given w/o a blank link preceding it. This causes the sample HTML code to be interpreted as part of the documentation

For example, the first sample code from [MaterialPopupComponent](https://webdev.dartlang.org/components/api/angular_components/MaterialPopupComponent-class) used to render as
```
Example use:  Toggle  Hello World
```
It now properly renders as:
```
Example use:

    <button (click)="showPopup = !showPopup"
            popupSource
            #source="popupSource">
      Toggle
    </button>
    <material-popup [visible]="showPopup" [source]="source">
      Hello World
    </material-popup>
```

cc @kwalrath 