### PR TITLE
Add switch to disable deselect for material-select

### DIFF
--- a/lib/src/components/material_select/material_dropdown_select.dart
+++ b/lib/src/components/material_select/material_dropdown_select.dart
@@ -17,6 +17,7 @@ import '../../model/selection/selection_model.dart';
 import '../../model/selection/selection_options.dart';
 import '../../model/ui/has_renderer.dart';
 import '../../model/ui/template_support.dart';
+import '../../utils/angular/properties/properties.dart';
 import '../../utils/id_generator/id_generator.dart';
 import '../annotations/rtl_annotation.dart';
 import '../content/deferred_content.dart';
@@ -260,6 +261,17 @@ class MaterialDropdownSelectComponent extends MaterialSelectBase
       }
     });
   }
+
+  /// Whether to allow deselecting an already selected item.
+  ///
+  /// True by default.
+  bool get allowDeselect => _allowDeselect;
+  @Input()
+  set allowDeselect(value) {
+    _allowDeselect = getBool(value);
+  }
+
+  bool _allowDeselect = true;
 
   void _updateActiveModel() {
     var items = new List<dynamic>.from(options?.optionsList ?? []);

--- a/lib/src/components/material_select/material_dropdown_select.html
+++ b/lib/src/components/material_select/material_dropdown_select.html
@@ -79,6 +79,7 @@
                 [disabled]="isOptionDisabled(item)"
                 [value]="item"
                 [active]="activeModel.isActive(item)"
+                [allowDeselect]="allowDeselect"
                 [attr.id]="activeModel.id(item)"
                 (mouseenter)="activeModel.activate(item)">
             </material-select-dropdown-item>

--- a/lib/src/components/material_select/material_select_item.dart
+++ b/lib/src/components/material_select/material_select_item.dart
@@ -231,7 +231,8 @@ class MaterialSelectItemComponent extends ButtonDirective
 
     if (_activationHandler?.handle(e, value) ?? false) return;
     if (selectOnActivate && _selection != null && value != null) {
-      if (allowDeselect && _selection.isSelected(value)) {
+      if (_selection.isSelected(value)) {
+        if (!allowDeselect) return;
         _selection.deselect(value);
       } else {
         _selection.select(value);

--- a/lib/src/components/material_select/material_select_item.dart
+++ b/lib/src/components/material_select/material_select_item.dart
@@ -202,6 +202,17 @@ class MaterialSelectItemComponent extends ButtonDirective
 
   bool _closeOnActivate = true;
 
+  /// Whether to allow deselecting an already selected item.
+  ///
+  /// True by default.
+  bool get allowDeselect => _allowDeselect;
+  @Input()
+  set allowDeselect(value) {
+    _allowDeselect = getBool(value);
+  }
+
+  bool _allowDeselect = true;
+
   Type get componentType =>
       componentRenderer != null ? componentRenderer(value) : null;
 
@@ -220,7 +231,7 @@ class MaterialSelectItemComponent extends ButtonDirective
 
     if (_activationHandler?.handle(e, value) ?? false) return;
     if (selectOnActivate && _selection != null && value != null) {
-      if (_selection.isSelected(value)) {
+      if (allowDeselect && _selection.isSelected(value)) {
         _selection.deselect(value);
       } else {
         _selection.select(value);


### PR DESCRIPTION
This change allows you to have a dropdown list where you can select an item, but once selected, you can no longer deselect the already selected item by clicking on it again. This is usually wanted for a single select dropdown list (not so much for a multi select dropdown list usually).

Example (notice the `allowDeselect` property):
```html
<material-dropdown-select
  [options]="selectOptions"
  [selection]="selectionModel"
  [allowDeselect]="false">
</material-dropdown-select>
```