### PR TITLE
Add custom builder for .scss.css files

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -1,0 +1,25 @@
+targets:
+  angular_components:
+    sources:
+      exclude: ["lib/builder.dart"]
+    builders:
+      sass_builder|sass_builder:
+        enabled: False
+      angular_components|scss_builder:
+        enabled: True
+  scss_builder:
+    sources: ["lib/builder.dart"]
+    dependencies:
+      - build
+      - sass_builder
+
+
+builders:
+  scss_builder:
+    target: "scss_builder"
+    import: "package:angular_components/builder.dart"
+    builder_factories: ["scssBuilder"]
+    build_to: cache
+    build_extensions:
+      .scss: [".scss.css"]
+      .sass: [".scss.css"]

--- a/lib/builder.dart
+++ b/lib/builder.dart
@@ -1,0 +1,5 @@
+import 'package:build/build.dart';
+import 'package:sass_builder/sass_builder.dart';
+
+Builder scssBuilder(BuilderOptions options) =>
+    new SassBuilder(outputExtension: '.scss.css');


### PR DESCRIPTION
This package uses a different output extension than the default for
`sass_builder`. Since a Builder definition in a `build.yaml` may not
change it's extensions based on BuilderOptions we need a separate
builder.