### PR TITLE
Allow MaterialMenuComponent to pass "raised" value to child MaterialButtonComponent

### DIFF
--- a/angular_components/lib/material_menu/material_menu.dart
+++ b/angular_components/lib/material_menu/material_menu.dart
@@ -81,6 +81,10 @@ class MaterialMenuComponent extends Object
   @Input()
   bool tabbable = true;
 
+  /// Whether the menu is raised or not.
+  @Input()
+  bool raised = false;
+
   /// Aria label for button trigger.
   @Input()
   String ariaLabel;

--- a/angular_components/lib/material_menu/material_menu.html
+++ b/angular_components/lib/material_menu/material_menu.html
@@ -9,6 +9,7 @@
     [attr.icon]="hasIcon"
     [disabled]="disabled"
     [tabbable]="tabbable"
+    [raised]="raised"
     [materialTooltip]="tooltipText"
     [showTooltipIf]="hasTooltip"
     class="trigger-button"


### PR DESCRIPTION
## Issue:
Currently the standard angular_components library allows for "raised" buttons via the [MaterialButtonComponent](https://webdev.dartlang.org/api/angular_components/angular_components/MaterialButtonComponent-class) but only allows for "flat" buttons inside of a [MaterialMenuComponent](https://webdev.dartlang.org/api/angular_components/angular_components/MaterialMenuComponent-class.html), even though the MaterialMenuComponent is backed by a MaterialButtonComponent. Combining the two styles looks like the following:
![flatmenu](https://user-images.githubusercontent.com/7257907/53678323-50bcce80-3c72-11e9-870c-980435d2d322.gif)

## Solution:
Create a parameter value that can be issued to the MaterialMenuComponent and pass it directly to the MaterialButtonComponent. The MaterialButtonComponent then applies the correct CSS values to itself and nothing else needs to be done. The result of that parameter passing looks like this:
![raisedmenu](https://user-images.githubusercontent.com/7257907/53678350-abeec100-3c72-11e9-93ad-e326bd9cedb2.gif)

Discussion:
1. One of the keys behind Material Design Guidelines (MDG) is consistency - ["consistent UI regions"](https://material.io/design/layout/understanding-layout.html#usage) are one of the first concepts on [Google's own MDG site.](https://material.io) By allowing buttons and menus to co-exist in the visual space without providing two different appearances, the raised menu allows much more consistency in UI for this component set.

2. The famous Floating Action Button [has an obvious shadow](https://material.io/design/components/buttons-floating-action-button.html#) and the guidelines allow for a larger ["Extended Floating Action Button"](https://material.io/design/components/buttons-floating-action-button.html#extended-fab) that contains text and does not require an icon to adhere to MDG. Furthermore, using an FAB to [display an expanding action menu](https://material.io/design/components/buttons-floating-action-button.html#types-of-transitions) is also a part of the core guidelines.

3. Default behavior is un-changed and patching the change will not break existing code. The change simply allows users to better interact with custom menus at their own discretion, mirrors existing component API usage, and fully uses existing components with no new types or directives.