### PR TITLE
Do not set Date Range picker height

### DIFF
--- a/angular_components/lib/material_datepicker/material_date_range_picker.scss
+++ b/angular_components/lib/material_datepicker/material_date_range_picker.scss
@@ -7,7 +7,6 @@
 @import 'package:angular_components/material_select/mixins';
 
 $apply-height: $mat-grid * 6;
-$datepicker-main-content-height: $mat-grid * 9;
 
 $main-font-size: 13px;
 
@@ -62,7 +61,6 @@ $main-font-size: 13px;
   flex-direction: column;
   justify-content: center;
   cursor: pointer;
-  height: $datepicker-main-content-height;
 
   :host(.disabled) & {
     cursor: not-allowed;


### PR DESCRIPTION
I don't see a reason why to set fixed height for date range picker. Other date pickers have auto height as well.
I removed the height definition and didn't find anything wrong after the change. Please merge PR if you don't object.

Signed-off-by: Martin Edlman <ac@an.y-co.de>