### PR TITLE
Pass factoryRenderer through to MaterialTreeComponent

### DIFF
--- a/angular_components/lib/src/material_tree/material_tree_dropdown.html
+++ b/angular_components/lib/src/material_tree/material_tree_dropdown.html
@@ -48,6 +48,7 @@
   <ng-content select="[post-header]"></ng-content>
   <material-tree
     *deferredContent
+    [factoryRenderer]="factoryRenderer"
     [componentRenderer]="componentRenderer"
     [expandAll]="expandAll"
     [allowParentSingleSelection]="allowParentSingleSelection"


### PR DESCRIPTION
factoryRenderer isn't functional in MaterialTreeDropdownComponent because it's not being passed to the MaterialTreeComponent. Seems like a simple oversight.