### PR TITLE
Fix material tree selection change detection

### DIFF
--- a/angular_components/lib/src/material_tree/material_tree_node.dart
+++ b/angular_components/lib/src/material_tree/material_tree_node.dart
@@ -56,6 +56,9 @@ class MaterialTreeNode<T> {
     } else {
       _selectable = _AlwaysSelectable<T>();
     }
+
+    _root.selection.selectionChanges
+        .listen((_) => _changeDetector.markForCheck());
   }
 
   /// Whether all visible options should be expanded.
@@ -162,7 +165,14 @@ class MaterialTreeNode<T> {
       !hasChildren(option);
 
   /// Returns whether [option] is selected.
-  bool isSelected(T option) => _root.selection.isSelected(option);
+  bool isSelected(T option) {
+    if (_root.selection.isSelected(option)) {
+      print('option: ${option}');
+    } else {
+      print('no checked ${option}');
+    }
+    return _root.selection.isSelected(option);
+  }
 
   /// Returns any child groups of [option] that are loaded.
   Iterable<OptionGroup> getChildGroups(option) => _expandedNodes[option];

--- a/angular_components/lib/src/material_tree/material_tree_node.dart
+++ b/angular_components/lib/src/material_tree/material_tree_node.dart
@@ -165,14 +165,7 @@ class MaterialTreeNode<T> {
       !hasChildren(option);
 
   /// Returns whether [option] is selected.
-  bool isSelected(T option) {
-    if (_root.selection.isSelected(option)) {
-      print('option: ${option}');
-    } else {
-      print('no checked ${option}');
-    }
-    return _root.selection.isSelected(option);
-  }
+  bool isSelected(T option) => _root.selection.isSelected(option);
 
   /// Returns any child groups of [option] that are loaded.
   Iterable<OptionGroup> getChildGroups(option) => _expandedNodes[option];


### PR DESCRIPTION
This an attempt to fix #478 

I suspect this is a regression caused by this commit: https://github.com/dart-lang/angular_components/commit/259039e1ee9ee540c581684e7b0cdae345dfa101. I found to this commit by going through the history to look for anything that affects change detection. And this is exactly something to do with that. Reverting these changes (removing the new lines added) will fix this issue. 

Of course, I am not suggesting undoing these changes. I understand there was a warning about `ChangeDetection.OnPush` during the building of Angular web application since the `angular 6.0.0` upgrade.

So, I thought the correct way is to make `MaterialTreeNode` to be aware of the selection changes, and mark itself for check.

I have tried to do this selection change detection in the parent component `MaterialTreeComponent` but failed to find a way to do it from there. So I resorted to do this detection in each tree node.

I have see this fix in my own reproducing project: https://github.com/yuan-kuan/angulardart-broken-tree. And also the Angular Component Example project (I forked and cloned it and tested locally in my machine.)